### PR TITLE
Use srv-configs for discovery only if it exists

### DIFF
--- a/yelp_kafka/config.py
+++ b/yelp_kafka/config.py
@@ -40,7 +40,7 @@ from yelp_kafka.utils import memoized
 DEFAULT_KAFKA_TOPOLOGY_BASE_PATH = '/nail/srv/configs/kafka_discovery_configs'
 # Use /etc/kafka_discovery if /nail/srv/configs/kafka_discovery does not exist
 if not os.path.isdir(DEFAULT_KAFKA_TOPOLOGY_BASE_PATH):
-    DEFAULT_KAFKA_TOPOLOGY_BASE_PATH = '/etc/kafka_discovery'
+    DEFAULT_KAFKA_TOPOLOGY_BASE_PATH = '/nail/etc/kafka_discovery'
 
 # This is fixed to 2MiB, which is twice as much as the max message size
 # configured by default in our Kafka clusters.

--- a/yelp_kafka/config.py
+++ b/yelp_kafka/config.py
@@ -37,7 +37,10 @@ from yelp_kafka.error import ConfigurationError
 from yelp_kafka.utils import memoized
 
 
-DEFAULT_KAFKA_TOPOLOGY_BASE_PATH = '/nail/etc/kafka_discovery'
+DEFAULT_KAFKA_TOPOLOGY_BASE_PATH = '/nail/srv/configs/kafka_discovery_configs'
+# Use /etc/kafka_discovery if /nail/srv/configs/kafka_discovery does not exist
+if not os.path.isdir(DEFAULT_KAFKA_TOPOLOGY_BASE_PATH):
+    DEFAULT_KAFKA_TOPOLOGY_BASE_PATH = '/etc/kafka_discovery'
 
 # This is fixed to 2MiB, which is twice as much as the max message size
 # configured by default in our Kafka clusters.

--- a/yelp_kafka/config.py
+++ b/yelp_kafka/config.py
@@ -38,7 +38,7 @@ from yelp_kafka.utils import memoized
 
 
 DEFAULT_KAFKA_TOPOLOGY_BASE_PATH = '/nail/srv/configs/kafka_discovery_configs'
-# Use /etc/kafka_discovery if /nail/srv/configs/kafka_discovery does not exist
+# Use /nail/etc/kafka_discovery if /nail/srv/configs/kafka_discovery does not exist
 if not os.path.isdir(DEFAULT_KAFKA_TOPOLOGY_BASE_PATH):
     DEFAULT_KAFKA_TOPOLOGY_BASE_PATH = '/nail/etc/kafka_discovery'
 


### PR DESCRIPTION
This changes the default directory used to read kafka discovery config files from /etc/kafka_discovery to /nail/srv/configs/kafka_discovery_configs. However, it only uses the srv-configs directory if it exists on the host, otherwise we continue using the /etc/kafka_discovery directory for cluster discovery configuration files. The actual format of the files does not change.

This will be released with a patch version bump.